### PR TITLE
Remove string operations from dictionary benchmarks

### DIFF
--- a/ObjC Speed Test/ObjC Speed Test.xcodeproj/xcshareddata/xcschemes/ObjC Speed Test.xcscheme
+++ b/ObjC Speed Test/ObjC Speed Test.xcodeproj/xcshareddata/xcschemes/ObjC Speed Test.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AE93BB8A1C8724D100655274"
+               BuildableName = "ObjC Speed Test.app"
+               BlueprintName = "ObjC Speed Test"
+               ReferencedContainer = "container:ObjC Speed Test.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AE93BBA31C8724D100655274"
+               BuildableName = "ObjC Speed TestTests.xctest"
+               BlueprintName = "ObjC Speed TestTests"
+               ReferencedContainer = "container:ObjC Speed Test.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE93BB8A1C8724D100655274"
+            BuildableName = "ObjC Speed Test.app"
+            BlueprintName = "ObjC Speed Test"
+            ReferencedContainer = "container:ObjC Speed Test.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE93BB8A1C8724D100655274"
+            BuildableName = "ObjC Speed Test.app"
+            BlueprintName = "ObjC Speed Test"
+            ReferencedContainer = "container:ObjC Speed Test.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE93BB8A1C8724D100655274"
+            BuildableName = "ObjC Speed Test.app"
+            BlueprintName = "ObjC Speed Test"
+            ReferencedContainer = "container:ObjC Speed Test.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ObjC Speed Test/ObjC Speed TestTests/DictionaryTests.m
+++ b/ObjC Speed Test/ObjC Speed TestTests/DictionaryTests.m
@@ -25,7 +25,7 @@
 - (NSMutableDictionary *)dictionaryWithElements {
     NSMutableDictionary *dictionary = [NSMutableDictionary new];
     for (NSInteger i = 0; i < self.repeatCount; i++) {
-        dictionary[[NSString stringWithFormat:@"%li", (long)i]] = [NSString stringWithFormat:@"%i", arc4random_uniform(1000)];
+        dictionary[@(i)] = @(i);
     }
     
     return dictionary;
@@ -47,28 +47,26 @@
 
     [self measureBlock:^{
         for (NSInteger i = 0; i < self.repeatCount; i++) {
-            string = self.dictionary[[NSString stringWithFormat:@"%li", (long)i]];
+            string = self.dictionary[@(i)];
         }
     }];
 }
 
 - (void)testRemove {
-#warning It contains time for refilling the dictionary, so should subtract avg time testAdd from the result.
     [self measureBlock:^{
         for (NSInteger i = 0; i < self.repeatCount; i++) {
-            [self.dictionary removeObjectForKey:[NSString stringWithFormat:@"%li", (long)i]];
+            [self.dictionary removeObjectForKey:@(i)];
         }
-        self.dictionary = [self dictionaryWithElements];
     }];
 }
 
 - (void)testFastEnum {
-    __block NSString *string;
+    __block NSNumber *number;
     
     [self measureBlock:^{
-        for (NSString *key in self.dictionary) {
-            NSString *value = [self.dictionary valueForKey:key];
-            string = [key stringByAppendingString:value];
+        for (NSNumber *key in self.dictionary) {
+            NSNumber *value = self.dictionary[key];
+            number = value;
         }
     }];
 }

--- a/Swift Speed Test/Swift Speed Test.xcodeproj/project.pbxproj
+++ b/Swift Speed Test/Swift Speed Test.xcodeproj/project.pbxproj
@@ -360,11 +360,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
+				GCC_OPTIMIZATION_LEVEL = 3;
 				INFOPLIST_FILE = "Swift Speed TestTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.droidsonroids.Swift-Speed-TestTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift Speed Test.app/Swift Speed Test";
 			};
 			name = Debug;
@@ -374,11 +375,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
+				GCC_OPTIMIZATION_LEVEL = 3;
 				INFOPLIST_FILE = "Swift Speed TestTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.droidsonroids.Swift-Speed-TestTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift Speed Test.app/Swift Speed Test";
 			};
 			name = Release;

--- a/Swift Speed Test/Swift Speed Test.xcodeproj/xcshareddata/xcschemes/Swift Speed Test.xcscheme
+++ b/Swift Speed Test/Swift Speed Test.xcodeproj/xcshareddata/xcschemes/Swift Speed Test.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AE9C4A7D1C8724F1001D1B49"
+               BuildableName = "Swift Speed Test.app"
+               BlueprintName = "Swift Speed Test"
+               ReferencedContainer = "container:Swift Speed Test.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AE9C4A911C8724F2001D1B49"
+               BuildableName = "Swift Speed TestTests.xctest"
+               BlueprintName = "Swift Speed TestTests"
+               ReferencedContainer = "container:Swift Speed Test.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE9C4A7D1C8724F1001D1B49"
+            BuildableName = "Swift Speed Test.app"
+            BlueprintName = "Swift Speed Test"
+            ReferencedContainer = "container:Swift Speed Test.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE9C4A7D1C8724F1001D1B49"
+            BuildableName = "Swift Speed Test.app"
+            BlueprintName = "Swift Speed Test"
+            ReferencedContainer = "container:Swift Speed Test.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE9C4A7D1C8724F1001D1B49"
+            BuildableName = "Swift Speed Test.app"
+            BlueprintName = "Swift Speed Test"
+            ReferencedContainer = "container:Swift Speed Test.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swift Speed Test/Swift Speed TestTests/DictionaryTests.swift
+++ b/Swift Speed Test/Swift Speed TestTests/DictionaryTests.swift
@@ -11,22 +11,22 @@ import XCTest
 class DictionaryTests: XCTestCase {
     
     let repeatCount = 1_000_000
-    var dictionary = [String: String]()
+    var dictionary = [Int: Int]()
     
-    func dictionaryWithElements() -> [String: String] {
-        var dictionary = [String: String]()
+    func dictionaryWithElements() -> [Int: Int] {
+        var dictionary = [Int: Int]()
         for i in 0..<repeatCount {
-            dictionary["\(i)"] = "\(arc4random_uniform(1000))"
+            dictionary[i] = i
         }
         
         return dictionary
     }
-    
+
     override func setUp() {
         super.setUp()
         dictionary = dictionaryWithElements()
     }
-    
+
     func testAdd() {
         measureBlock { 
             _ = self.dictionaryWithElements()
@@ -34,37 +34,38 @@ class DictionaryTests: XCTestCase {
     }
     
     func testAccess() {
-        var string = String?()
+        var integer: Int?
         
         measureBlock { 
             for i in 0..<self.repeatCount {
-                string = self.dictionary["\(i)"]
+                integer = self.dictionary[i]
             }
         }
         
-        print(string)
+        print(integer)
     }
     
-    // It contains time for refilling the dictionary, so should subtract avg time testAdd from the result.
     func testRemove() {
         measureBlock {
             for i in 0..<self.repeatCount {
-                self.dictionary.removeValueForKey("\(i)")
+                self.dictionary.removeValueForKey(i)
             }
-            self.dictionary = self.dictionaryWithElements()
         }
     }
     
     func testFastEnum() {
-        var string = String()
-        
+        var keyPlaceholder = Int()
+        var valuePlaceholder = Int()
+
         measureBlock { 
             for (key, value) in self.dictionary {
-                string = key + value
+                valuePlaceholder = value
+                keyPlaceholder = key
             }
         }
         
-        print(string)
+        print(valuePlaceholder)
+        print(keyPlaceholder)
     }
     
 }


### PR DESCRIPTION
Why?

Generating 2M elements of `String` took `~0.6s` (vs `~0.1s` of `Int`):

<img width="635" alt="screenshot of xcode 29-06-2016 10-44-45" src="https://cloud.githubusercontent.com/assets/3382607/16449922/742dca1e-3dfa-11e6-8f92-8f8739791f9b.png">

The test is about NSDictionary/Dictionary not String (formatting etc.) there should be some separate test showing the differences.

Just wanted to remove `String`/`NSString` of of the equation and test `Int` vs `NSNumber` in `Dictionary` to show the power of  stack based (when small) Value Types.

I know - we're using the advantage of Swift but for this example (lots of numbers) this is the whole point. We should convert only those we present and I don't see any way of showing 1M numbers to the user as strings 😀 

**SIDE NOTE** Who needs 1M of random numbers as Strings in Dictionary? But 1M numbers:numbers is another story, this is not even synthetic - one can imagine data for plotting a chart.

RESULT:

<img width="933" alt="screenshot of xcode 29-06-2016 13-16-51" src="https://cloud.githubusercontent.com/assets/3382607/16450149/c58a96ac-3dfb-11e6-97e5-4328e411bcd3.png">

Just wanted to show my point, not fix every benchmark.

What do you think @sochalewski ?
